### PR TITLE
Use np.array for typing, remove parameter unfreeze

### DIFF
--- a/s5/ssm.py
+++ b/s5/ssm.py
@@ -89,10 +89,10 @@ def apply_ssm(Lambda_bar, B_bar, C_tilde, input_sequence, conj_sym, bidirectiona
 
 
 class S5SSM(nn.Module):
-    Lambda_re_init: np.DeviceArray
-    Lambda_im_init: np.DeviceArray
-    V: np.DeviceArray
-    Vinv: np.DeviceArray
+    Lambda_re_init: np.array
+    Lambda_im_init: np.array
+    V: np.array
+    Vinv: np.array
 
     H: int
     P: int

--- a/s5/train_helpers.py
+++ b/s5/train_helpers.py
@@ -132,11 +132,10 @@ def create_train_state(model_cls,
                            dummy_input, integration_timesteps,
                            )
     if batchnorm:
-        params = variables["params"].unfreeze()
+        params = variables["params"]
         batch_stats = variables["batch_stats"]
     else:
-        params = variables["params"].unfreeze()
-        # Note: `unfreeze()` is for using Optax.
+        params = variables["params"]
 
     if opt_config in ["standard"]:
         """This option applies weight decay to C, but B is kept with the


### PR DESCRIPTION
This PR makes two small changes to work with newer versions of Jax and Flax. 
* The typing in `ssm.py` is changed to `np.array` as `np.DeviceArray` is deprecated
* Remove the `unfreeze()` call in `train_helper.py`