### PR TITLE
relax python requirement to >=3.9.2, add cpu requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,13 @@ Please reach out if you have any questions or feedback.
 
 
 ## Installation instructions
-Create a new virtual environment with `python>=3.12.1` and execute
+Create a new virtual environment with `python>=3.9.2` and execute
 ```
-pip install .
-pip install -r requirements.txt
+pip install -r requirements_{cpu,gpu}.txt
+pip install -e .
 ```
+
+GPU installation expecteds Cuda12, and pip installation includes NVIDIA CUDA and cuDNN.
+This is only available for x86_64 and aarch64 platforms.
+See the Jax installation page for more details
+[(link)](https://jax.readthedocs.io/en/latest/installation.html#pip-installation-nvidia-gpu-cuda-installed-via-pip-easier).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,23 +10,23 @@ authors = [
 ]
 description = "S5 deep state space model and extensions"
 readme = "README.md"
-requires-python = ">=3.12.1"
+requires-python = ">=3.9.2"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-# # Automatic installation from file is not currently supported
-# # and require manual installation (see README.md)
-# # due to use of pip flags within requirements file.
-# # See: https://stackoverflow.com/a/73600610
-# dynamic = ["dependencies", "optional-dependencies"]
+# Automatic installation from file is not currently supported
+# and require manual installation (see README.md)
+# due to the use of pip flags within the requirements file.
+# See: https://stackoverflow.com/a/73600610
+dynamic = ["dependencies", "optional-dependencies"]
 
 [project.urls]
 Homepage = "https://github.com/lindermanlab/S5/tree/development"
 
 [tool.setuptools.dynamic]
-# # Automatic installation from requirements file not currently supported;
-# # see comment above. Lines retained here for documentation.
+# Automatic installation from requirements file not currently supported;
+# see comment above. Lines retained here for documentation.
 # dependencies = {file = ["requirements.txt"]}
 # optional-dependencies = {dev = {file = ["requirements-dev.txt"]}}

--- a/requirements_cpu.txt
+++ b/requirements_cpu.txt
@@ -1,0 +1,17 @@
+chex
+datasets
+einops
+flax
+jax
+omegaconf
+optax
+pytorch-lightning
+scikit-learn
+transformers
+wandb
+
+# Specify pytorch CPU index to force CPU install.
+# The versions may possibly be relaxed or removed.
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch==2.3.0+cpu
+torchvision==0.18.0+cpu

--- a/requirements_gpu.txt
+++ b/requirements_gpu.txt
@@ -1,12 +1,8 @@
-# GPU requirements file
-
--f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
-jax[cuda12_pip]
-
 chex
 datasets
 einops
 flax
+jax[cuda12_pip]
 omegaconf
 optax
 pytorch-lightning


### PR DESCRIPTION
**testing**
verified cpu and gpu environments by running small test,
```
python train.py -o output_dir_name -c configs/hyena/associative_recall_131K_30_hyena.yaml
```
and ensuring finite train/val/test values