### PR TITLE
add autoregressive capability to `S5Operator`, `Block`, and `LMBackbone`

### DIFF
--- a/src/s5dev/models/s5.py
+++ b/src/s5dev/models/s5.py
@@ -460,6 +460,95 @@ def init_S5SSM(d_model, ssm_size, blocks, ssm_args):
 
 
 class S5Operator(nn.Module):
+    r"""Hyena Hierarchy model with recurrent multiplicative gating and long convolutions.
+
+    In brief, the Hyena Hierarchy model is a recurrence of depth (or order) N consisting of
+        - Element-wise multiplicative gating, as a subquadratic alternative to attention
+          that enables in-context learning,
+        - Long convolutions, to capture longer-range dependencies.
+    This is also referred to as the Hyena recurrence, or the order-N Hyena operator.
+
+    Long convolutions are defined as convolutions with filter sizes = input sequence length,
+    in contrast to "standard" convolutions with filter sizes << input sequence length.
+    Implicit parameterization of convolutions, i.e. as a parametric function of the time
+    step (or more generally, sequence position) have the advantage of decoupling filter
+    length and parameter costs.
+
+    In the original Hyena Hierarchy model, the long convolution was implicitly parameterized
+    by a feed-forward neural network (FFN) and a short explicit filter. While the neural
+    implicit parameterization of long convolutions can be evaluated efficiently,
+    a disadvantage of such a parametrization is that it loses its recurrent formulation,
+    and therefore the fast autoregressive generation that a DSSM parameterization of
+    convolutions can provide.
+
+    The use of the short explicit filter is not well motivated or experimentally justified
+    in the Hyena paper, but anecdotally it has been observed to improving training for
+    order / window size of ~3. It is suggested to be an learnable implementation of the
+    (fixed) shift SSM proposed in the H3 paper, which assisted with associative recall tasks.
+    It can also be partly motivated by its similarity to "smeared keys", or the linear
+    combination of current and previous tokens, that Olsson et al. argued are what allow
+    attention-based models to form induction heads and perform in-context learning.
+
+    This module implements the Hyena recurrence and provides the optionality (TODO) to choose
+    between long convolution filter parameterization classes.
+
+    Arguments
+        d_model: int. Dimension of model inputs.
+        n_layer: int. Number of model layers, (used for special scaled init)
+            # TODO Documentation needed
+        l_max: int. Maximum input sequence length.
+        ssm_size: int. State dimension of DSSM
+        ssm_blocks: int. Number of HiPPO blocks to initialze DSSM state matrix
+        order: int. Depth of the Hyena recurrence. default: 2, equivalent to H3 recurrence.
+        num_heads: int. Number of heads.  default: 1.  # TODO more documentation needed
+            Number of heads.
+        inner_factor: int. Projection dimension multiplier. default: 1.
+        num_blocks: int. Number of blocks in sequence length. default: 1.
+            Number of blocks to divide input sequence length into in order to fit in
+            GPU SRAM. This is used to efficiently compute FFT-based convolutions with
+            the Fused Block FFTConv (described in H3 paper). Not used here.
+        fused_bias_fc: bool. Whether to use fused bias FC. default: False
+            Whether to use fused dense projection module from the FlashAttention repo.
+            Not used here because JAX implementation.
+        outer_mixing: bool. Whether to mix the features of different projections. default: False.
+            TODO Not implemented yet.
+        drop_rate: float. Dropout probability. default: 0.0.
+        filter_dropout: float. Filter dropout rate. default: 0.0
+            Not implemented in Hyena-filter, and not used here.
+        filter_cls: str. Class to parameterize long convolutional filter.
+        post_order_ffn: bool. Whether to apply a dense layer between hyena recurrent projections. default: False.
+            Only potentially useful if order > 2. If order = 2, then simply adds an extra projection
+            before the output projection and the MLP.
+        jit_filter: bool. Whether JIT the implicit filter function. Defaults to False
+        short_filter_order: int. Length of the explicit short convolutional filter. default: 3.
+            Only used when evaluating `self.__call__`, not used in `self.step` (AR generation).
+            If short_filter_order=0, do not apply convolutional filter to input.
+            Applying filter has nice properties for training, but is not necessary.
+        activation_type: str. type of activation between kernel output and FFN. default: 'id'
+        return_state: bool. whether to return a state.
+        filter_args: dict, optional. Keyword arguments to pass to filter class. default: None.
+        d_output: int (optional). default: None.
+            Dimension of model outputs. If None, d_output set to d_model.        
+
+    Parameters (trainable)
+
+    Variables (non-trainable)
+
+    References
+    ----------
+    Fu*, Dao* et al. (2022).
+    "Hungry Hungry Hippos (H3): Towards Language Modeling with SSMs."
+    https://arxiv.org/abs/2212.14052
+
+    Olsson et al. (2022). "In-context learning and induction heads."
+    https://arxiv.org/abs/2209.11895
+
+    Poli, Massaroli, Nguyen, et al. (ICML, 2023).
+    "Hyena Hierarchy: Towards Larger Convolutional Language Models."
+    https://arxiv.org/pdf/2302.10866.pdf
+
+    """
+
     d_model: int
     n_layer: int
     l_max: int
@@ -481,33 +570,33 @@ class S5Operator(nn.Module):
     return_state: bool = False
     filter_args: dict = None
 
+    @property
+    def d_output(self):
+        return self.d_model
+
     def setup(self):
-        r"""
-        Hyena operator described in the paper https://arxiv.org/pdf/2302.10866.pdf
+        if self.d_model % self.num_heads != 0:
+            raise ValueError(f"Input dimension {self.d_model} must be divisible by the number of heads {self.num_heads}.")
+        
+        if self.l_max % self.num_blocks != 0:
+            raise ValueError(f"Maximum sequence length {self.l_max} must be divisible by block dimension {self.num_blocks}")
 
-        Args:
-            d_model (int): Dimension of the input and output embeddings (width of the layer)
-            n_layer (int): # of model layers, (used for special scaled init)
-            l_max: (int): Maximum input sequence length. Defaults to None
-            ssm_size: (int): Size of the ssm
-            ssm_blocks: (int): Number of initial blocks to use when initialzing SSM state matrix
-            order: (int): Depth of the Hyena recurrence. Defaults to 2
-            num_heads: (int): Number of heads. Defaults to 1
-            inner_factor: (int): Width multiplier. Defaults to 1
-            num_blocks: (int): Number of blocks in sequence length. Defaults to 1
-            fused_bias_fc: (bool): Whether to use fused bias FC. Defaults to False
-            drop_rate: (float): Dropout probability. Defaults to 0.0
-            filter_dropout: (float): Dropout probability for the filter. Defaults to 0.0
-            post_order_ffn: (bool): Apply a dense layer between steps of the recurrence. Defaults to False
-            jit_filter: (bool): Whether JIT the implicit filter function. Defaults to False
-            short_filter_order: (int): Length of the explicit input convolutional filter. Defaults to 3
-            activation_type: (str): type of act between kernel output and FF (default identity)
-            return_state: (bool): whether to return a state
-        """
+        if (self.filter_cls == 'hyena_S5'):
+            if (self.order > 2):
+                raise NotImplementedError(
+                    f"order > 2 recurrence is not yet supported for filter class {self.filter_cls},"
+                    f"but got order {self.order}."
+                )
+            
+        if (self.num_heads > 1):
+            raise ValueError(
+                f"num_heads > 1 is not supported for filter class {self.filter_cls}, but got {self.num_heads}. "
+                "Increasing number of heads likely doesn't contribute much to digonal SSM implentation."
+            )
+        
+        if (self.num_blocks > 1):
+            raise ValueError(f"num_blocks > 1 is not supported for filter class {self.filter_cls}, but got {self.num_blocks}.")
 
-        assert self.d_model % self.num_heads == 0, f'Model dimension {self.d_model} must be divisible by num heads {self.num_heads}'
-        assert self.l_max % self.num_blocks == 0, f'Maximum signal length {self.l_max} must be divisible by block dimension {self.num_blocks}'
-        block_dim = self.l_max // self.num_blocks
         self.head_dim = self.d_model // self.num_heads
 
         self.activation = Activation(self.activation_type)
@@ -516,7 +605,7 @@ class S5Operator(nn.Module):
         self.setup_filters(self.filter_cls, self.filter_args)
 
     def setup_projections(self, fused_bias_fc, inner_factor, initializer_range=0.02):
-        "Initializes input and output projections (over the width dimension)"
+        """Initializes input and output projections (over the width dimension)"""
 
         # if fused_bias_fc and FusedDense is None:
         if fused_bias_fc:
@@ -525,8 +614,8 @@ class S5Operator(nn.Module):
             linear_cls = nn.Dense
 
         out_kernel_init = flax_normal(stddev=initializer_range / math.sqrt(2 * self.n_layer))
-        self.out_proj = linear_cls(self.d_model, kernel_init=out_kernel_init)
-        self.in_proj = linear_cls((self.order + 1) * self.d_model)
+        self.out_proj = linear_cls(inner_factor * self.d_model, kernel_init=out_kernel_init) 
+        self.in_proj = linear_cls(inner_factor * (self.order + 1) * self.d_model)
         if self.post_order_ffn:
             self.ord_proj_w = self.param("ord_proj_w",
                                          normal(stddev=1/math.sqrt(self.head_dim)),
@@ -535,61 +624,99 @@ class S5Operator(nn.Module):
     def setup_filters(self, filter_cls, filter_args):
         "Initializes the explicit and implicit filters"
         assert self.order >= 2, f'Order must be at least 2, (got {self.order})'
-        total_width = self.d_model * self.inner_factor * (self.order + 1)
+        
+        d_inner = self.d_model * self.inner_factor * (self.order + 1)
 
-        self.short_filter = nn.Conv(total_width,
-                                    [self.short_filter_order],
-                                    feature_group_count=total_width,
-                                    padding=self.short_filter_order - 1)
+        if self.short_filter_order > 0:
+            self.short_filter = nn.Conv(d_inner,
+                                        [self.short_filter_order],
+                                        feature_group_count=d_inner,
+                                        padding=self.short_filter_order - 1)
 
         if self.filter_cls == 'hyena_S5':
-            # print('Using S5 for filters')
             self.filter_fn = [init_S5SSM(self.d_model, self.ssm_size, self.ssm_blocks, filter_args) for _ in range(self.order-1)]
         else:
             raise NotImplementedError("filter {} not implemented".format(self.filter_cls))
 
     @nn.compact
-    def __call__(self, u, training):
-        l = u.shape[-2]
-        l_filter = min(l, self.l_max)
-        u = self.in_proj(u)
-        # u = rearrange(u, 'b l d -> b d l')
+    def __call__(self, input_sequence, training):
+        """Apply order-N Hyena recurence to an input sequence
 
-        # note u is still 'b l d'
-        uc = self.short_filter(u)[:, :l_filter]
-        # uc is 'b l d'
-        uc = rearrange(uc, 'b l d -> b d l')
-        uc = rearrange(uc, 'b (ho v) (z l) -> b ho v z l',
-                       z=self.num_blocks,
-                       ho=self.num_heads,
-                       v=self.head_dim * (self.order + 1)
-                       )
+        Args:
+            input_sequence: Array[float32], shape (bsz, seq_len, d_model)
+            training: bool. If True, model is in training mode and dropout should be used.
+        
+        Returns:
+            output_sequence: Array[float32], shape (bsz, seq_len, d_output)
+        """      
 
-        width = uc.shape[2]
-        split_width = int(width // self.d_model)
-        *x, v = np.split(uc, split_width, axis=2)
+        # Make order+1 linear projections of the input, each with width (inner_factor * d_model,)
+        # These projections are denoted as (v, x1, ..., xN) in the Hyena paper (Defn. 3.1)
+        # u: shape (bsz, seq_len, d_inner), where d_inner = (order+1) * (inner_factor * d_model)
+        u = self.in_proj(input_sequence)
 
-        for o, x_i in enumerate(reversed(x[1:])):
+        # Apply short convolution, if specified
+        if self.short_filter_order > 0:
+            seq_len = input_sequence.shape[-2]
+            l_filter = min(seq_len, self.l_max)
+            uc = self.short_filter(u)[:, :l_filter]  # Short 1d convolution
+        else:
+            uc = u
+
+        # Reshape linear projections for multi-headed operation (not implemented)
+        # and applying filter to blocks of the sequence length (not implemened).
+        d_inner = uc.shape[-1]
+        uc = rearrange(uc, 'b l d -> b d l')  # now, bsz, d_inner, seq_len)
+        uc = rearrange(
+            uc, 'b (ho v) (z l) -> b ho v z l',
+            z=self.num_blocks, ho=self.num_heads, v=d_inner // self.num_heads,  # z=1, ho=1
+        )
+        # now, (bsz, n_heads, (order+1) * scaled_d_head, n_blocks, seq_len//n_blocks)
+        # where (d_inner // n_heads) = (order+1) * (inner_factor * d_model) // n_heads
+        #                            = (order+1) * (inner_factor * d_head)
+        #                            = (order+1) * scaled_d_head
+
+        # NOTE: The original pytorch implementation (see bottom of comment for permalink)
+        #   > *x, v = uc.split(self.d_model, dim=2)
+        # may have some formulation errors that may not have been detected due to
+        # (likely) only ever using n_heads = 1. Recall that `torch.split(arr, n)` creates
+        # m chunks of size n, whereas `np.split(arr, n)` create n chunks of size m.
+        # So, the original code intended create (order+1,) chunks of size (d_model,).
+        # However, additionally recall the second dimension of uc:
+        #   uc.shape[2] = d_inner // num_heads
+        #               = (self.order + 1) * inner_factor * d_model // num_heads
+        #               = (self.order + 1) * inner_factor * d_head
+        # Therefore, we acually likely want to split the 2nd axis of uc into (order+1,)
+        # chunks of size (inner_factor * d_head,) = scaled_d_head.
+        # https://github.com/HazyResearch/safari/blob/02220c69d247e5473616cd053a443ad99fd2559b/src/models/sequence/hyena.py#L323
+
+        *x, v = np.split(uc, self.order+1, axis=2) # (order+1,) projections, of shape (bsz, n_heads, scaled_d_head, n_blocks, seq_len//n_blocks)
+
+        # Work through linear projections in reverse (Question: Is doing this in reverse important??)
+        for o, x_o in enumerate(reversed(x[1:])):
             if self.outer_mixing:
                 raise NotImplementedError("outer mixing not implemented for hyena_S5 yet")
             else:
-                v = self.dropout(deterministic=not training)(v * x_i)
+                v = self.dropout(deterministic=not training)(v * x_o)
 
-            v = self.filter_fn[o](v)
+            # Apply long convolution
+            v = self.filter_fn[o](v) # input v is ndim=5 (batch_size, ho=1, scaled_d_model, z=1, seq_len)
 
+            # Apply another linear projection before the next recurrent. Not useful if order=2.
             if self.post_order_ffn:
                 w = self.ord_proj_w[o]
                 v = mul_sum(
                     rearrange(w, 'h1 h2 -> 1 h1 h2 1 1 1'), rearrange(v, 'b h v z l -> b h 1 v z l')
                 )
 
-        y = self.activation(rearrange(v * x[0], 'b h v z l -> b (z l) (h v)', z=self.num_blocks, h=self.num_heads))
+        v = v * x[0]  # elementwise-multiply with final projection
+        
+        # Finally, push mixed and convolved projections through activation and output
+        v = rearrange(v, 'b h v z l -> b (z l) (h v)', z=self.num_blocks, h=self.num_heads)  # now, (bsz, seq_len, d_inner)
+        y = self.activation(v)
         y = self.out_proj(y)
 
         if self.return_state:
             return y, None
-        return y
 
-    @property
-    def d_output(self):
-        return self.d_model
+        return y

--- a/src/s5dev/models/s5.py
+++ b/src/s5dev/models/s5.py
@@ -332,6 +332,7 @@ class S5SSM(nn.Module):
         
         return new_state, output
 
+
 def init_S5SSM(d_model, ssm_size, blocks, ssm_args):
     """Convenience function that will be used to initialize the SSM.
        Same arguments as defined in S5SSM above."""
@@ -360,6 +361,20 @@ def init_S5SSM(d_model, ssm_size, blocks, ssm_args):
                  H=d_model,
                  P=ssm_size,
                  **ssm_args)
+
+
+class IdentitySSM(nn.Module):
+    """No-op sequence-to-sequence module.
+
+    For a given input sequence, returns sequence. Used for debugging.
+    """
+
+    def __call__(self, input_sequence, training=True):
+        return input_sequence
+
+    def step(self, state, inpt, training=False):
+        return state, inpt
+
 
 
 class S5Operator(nn.Module):
@@ -537,6 +552,8 @@ class S5Operator(nn.Module):
                 init_S5SSM(self.d_model * self.inner_factor, self.ssm_size, self.ssm_blocks, filter_args)
                 for _ in range(self.order-1)
             ]
+        elif self.filter_cls == 'identity':
+            self.filter_fn = [IdentitySSM() for _ in range(self.order-1)]
         else:
             raise NotImplementedError("filter {} not implemented".format(self.filter_cls))
 

--- a/src/s5dev/models/simple_lm.py
+++ b/src/s5dev/models/simple_lm.py
@@ -5,6 +5,7 @@ import math
 
 from flax import linen as nn
 from flax.linen.initializers import normal as flax_normal
+import jax
 import jax.numpy as np
 
 from s5dev.models.s5 import S5Operator
@@ -255,7 +256,7 @@ class Block(nn.Module):
                 mixer_kwargs['mixer_subset'] = mixer_subset
             
             new_mixer_state, hidden_state = self.mixer.step(mixer_state, hidden_state, **mixer_kwargs)
-
+            
             if mixer_subset is not None:
                 residual = residual[:, mixer_subset]  # Take a subset before applying the query projectin.
 
@@ -306,6 +307,9 @@ def create_mixer_cls(layer=None, d_model=None, n_layer=None, l_max=None, layer_k
         elif layer.lower() == "s5_operator":
             mixer_cls = S5Operator(d_model, n_layer, l_max, **layer_kwargs)
         
+        elif layer.lower() == "identity":
+            mixer_cls = S5Operator(d_model, n_layer, l_max, filter_cls='identity', **layer_kwargs)
+
         else:
             raise ValueError(
                 f"Expected layer to be one of 'hyena' or 's5_operator', but got {layer}."

--- a/tests/models/test_simple_lm.py
+++ b/tests/models/test_simple_lm.py
@@ -1,0 +1,86 @@
+import pytest
+
+import numpy.testing  # provides more informative failure messages
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+
+from s5dev.models.simple_lm import create_block
+
+DEFAULT_RNG = jr.PRNGKey(21350)
+
+DEFAULT_S5OPERATOR_KWARGS = dict(
+    ssm_size = 4,
+    ssm_blocks = 1,
+    order = 2,
+    inner_factor = 1,
+    drop_rate = 0.0,
+    filter_cls = 'hyena_S5',
+    short_filter_order = 0,  # must be 0 in order to compare __call__ and step implementations
+    filter_args = dict(
+        C_init = "complex_normal",
+        dt_min = 0.001,
+        dt_max = 0.1,
+        conj_sym = False,
+        clip_eigs = True,
+        activation = "gelu",
+    )
+)
+
+
+def test_block_step(layer='s5_operator', batch_size=64, seq_len=8, d_input=12, atol=1e-4, rtol=1e-3):
+    """Test Block autoregressive generation via `step` implementation.
+    
+    Only applicable for layers with `step` function implemented, e.g. layer='s5_operator'.
+    """
+
+    init_rng, data_rng = jr.split(DEFAULT_RNG)
+
+    input_seq = jr.normal(data_rng, shape=(batch_size, seq_len, d_input))
+    init_residual = None
+
+    # Initialize Block
+    if layer == 's5_operator':
+        layer_kwargs = DEFAULT_S5OPERATOR_KWARGS
+    
+    model = create_block(
+        d_input, n_layer=1, l_max=seq_len, 
+        layer=layer, layer_kwargs=layer_kwargs,
+        resid_dropout1=0.0, resid_dropout2=0.0,
+    )
+    model_variables = model.init(init_rng, jnp.zeros_like(input_seq), training=False)
+
+    # Generate reference output, using __call__
+    ys_refr, residuals_refr = model.apply(model_variables, input_seq, residual=init_residual, training=False)
+
+    # -----------------------------------------------------------------------------------
+    # Generate output autoregressively
+    init_state = jnp.zeros((batch_size, layer_kwargs['ssm_size']), dtype="complex")  # dtype="complex": allow jax backend to set correct precision
+
+    def _step(mixer_state, inpt):
+        new_mixer_state, output, residual = \
+            model.apply(model_variables, mixer_state, inpt, method='step', residual=init_residual)
+        return new_mixer_state, (output, residual)
+    
+    x, (ys_test_T, residuals_test_T) = jax.lax.scan(
+        _step, init_state, jnp.transpose(input_seq, (1,0,2))
+    )  # *_test_T shape: (seq_len, bsz, d_input)
+
+    ys_test = jnp.transpose(ys_test_T, (1,0,2))  # now, (bsz, seq_len, d_input)
+    residuals_test = jnp.transpose(residuals_test_T, (1,0,2))  # now, (bsz, seq_len, d_input)
+
+    # -----------------------------------------------------------------------------------
+
+    y_err = jnp.abs(ys_refr-ys_test)
+    res_err = jnp.abs(residuals_refr-residuals_test)
+    msg = ""
+    for lbl, err in (('y', y_err), ('res', res_err)):
+        msg += (f"{lbl}: (mean: {jnp.mean(err):.1e}, "
+                + f"P50: {jnp.percentile(err, 50):.1e}, "
+                + f"P90: {jnp.percentile(err, 90):.1e}). ")
+    print(msg)
+
+    numpy.testing.assert_allclose(ys_refr, ys_test, atol=atol, rtol=rtol)
+    numpy.testing.assert_allclose(residuals_refr, residuals_test, atol=atol, rtol=rtol)
+
+    assert x.dtype == jnp.array([], dtype="complex").dtype


### PR DESCRIPTION
All `step` implementations match their corresponding `__call__` implementations up to a tolerance of `(atol=1e-8, rtol=1e-7)` _in double-precision mode_.

Tolerance needs to be raised to `(atol~=5e-3, rtol=0)` in single-precision mode due to various sources of numerical imprecision. Sources of imprecision have been documented where identified (via manual stepping-through). Tests are forced to operate in double-precision mode to control for these types of errors and reveal implementation errors.

The parallel vs. autoregressive implementations of `LMBackbone` with multiple (>1) `S5Operator` layers was found to have discrepancies after the first block; this is believed to be due to imprecision in the carried state. Please refer to the `test_simply_lm.py::test_lmbackbone_step` function for more details.

cc: Kelly for visibility